### PR TITLE
Add support for tags embedded in names of stats.

### DIFF
--- a/src/main/java/com/github/jjagged/metrics/reporting/statsd/StatsD.java
+++ b/src/main/java/com/github/jjagged/metrics/reporting/statsd/StatsD.java
@@ -125,7 +125,7 @@ public class StatsD implements Closeable {
         }
 
         try {
-            String formatted = String.format("%s:%s|g%s", sanitize(finalName), sanitize(value), buildTags(tags));
+            String formatted = String.format("%s:%s|g%s", sanitize(finalName), sanitize(value), buildTags(finalTags));
             byte[] bytes = formatted.getBytes(UTF_8);
             socket.send(socketFactory.createPacket(bytes, bytes.length, address));
             failures = 0;
@@ -163,14 +163,14 @@ public class StatsD implements Closeable {
         return WHITESPACE.matcher(s).replaceAll("-");
     }
 
-    private String buildTags(@Nullable final String[] tags) {
-        if (tags == null || tags.length == 0) {
+    private String buildTags(@Nullable final List<String> tags) {
+        if (tags == null || tags.size() == 0) {
             return "";
         }
         StringBuilder sb = new StringBuilder("|#");
-        for (int i = 0; i < tags.length; i++) {
-            sb.append(tags[i]);
-            if (i < tags.length - 1) {
+        for (int i = 0; i < tags.size(); i++) {
+            sb.append(tags.get(i));
+            if (i < tags.size() - 1) {
                 sb.append(",");
             }
         }

--- a/src/main/java/com/github/jjagged/metrics/reporting/statsd/StatsD.java
+++ b/src/main/java/com/github/jjagged/metrics/reporting/statsd/StatsD.java
@@ -25,6 +25,10 @@ import java.io.IOException;
 import java.net.DatagramSocket;
 import java.net.InetSocketAddress;
 import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -37,6 +41,8 @@ public class StatsD implements Closeable {
 
     private static final Pattern WHITESPACE = Pattern.compile("[\\s]+");
 
+    private static final Pattern TAGPATTERN = Pattern.compile("(.*)\\[(.*)\\]");
+
     private static final Charset UTF_8 = Charset.forName("UTF-8");
 
     private final DatagramSocketFactory socketFactory;
@@ -48,7 +54,7 @@ public class StatsD implements Closeable {
     /**
      * Creates a new client which connects to the given address using the
      * default {@link DatagramSocketFactory}.
-     * 
+     *
      * @param host
      *            the hostname of the StatsD server.
      * @param port
@@ -61,7 +67,7 @@ public class StatsD implements Closeable {
     /**
      * Creates a new client which connects to the given address and socket
      * factory.
-     * 
+     *
      * @param address
      *            the address of the StatsD server
      * @param socketFactory
@@ -76,7 +82,7 @@ public class StatsD implements Closeable {
      * Resolves the address hostname if present.
      * <p/>
      * Creates a datagram socket through the factory.
-     * 
+     *
      * @throws IllegalStateException
      *             if the client is already connected
      * @throws IOException
@@ -96,7 +102,7 @@ public class StatsD implements Closeable {
 
     /**
      * Sends the given measurement to the server. Logs exceptions.
-     * 
+     *
      * @param name
      *            the name of the metric
      * @param value
@@ -104,8 +110,22 @@ public class StatsD implements Closeable {
      */
     public void send(final String name, final String value, @Nullable final String[] tags) {
 
+        List<String> finalTags = new ArrayList<String>();
+        if(tags != null) {
+            finalTags.addAll(Arrays.asList(tags));
+        }
+
+        Matcher matcher = TAGPATTERN.matcher(name);
+
+        String finalName = name;
+        if (matcher.find() && matcher.groupCount() == 2) {
+            // We've got a tag in the name, so lets pull it out
+            finalName = matcher.group(1); // Get the name with no tags
+            finalTags.addAll(Arrays.asList(sanitize(matcher.group(2)).split(",")));
+        }
+
         try {
-            String formatted = String.format("%s:%s|g%s", sanitize(name), sanitize(value), buildTags(tags));
+            String formatted = String.format("%s:%s|g%s", sanitize(finalName), sanitize(value), buildTags(tags));
             byte[] bytes = formatted.getBytes(UTF_8);
             socket.send(socketFactory.createPacket(bytes, bytes.length, address));
             failures = 0;
@@ -124,7 +144,7 @@ public class StatsD implements Closeable {
 
     /**
      * Returns the number of failed writes to the server.
-     * 
+     *
      * @return the number of failed writes to the server
      */
     public int getFailures() {

--- a/src/test/java/com/github/jjagged/metrics/reporting/statsd/StatsDTest.java
+++ b/src/test/java/com/github/jjagged/metrics/reporting/statsd/StatsDTest.java
@@ -107,18 +107,45 @@ public class StatsDTest {
     }
 
     @Test
+    public void findsTags() throws Exception {
+        statsD.connect();
+        statsD.send("name[foo=bar]", "value", null);
+
+        assertThat(new String(bytesCaptor.getValue()))
+                .isEqualTo("name:value|g|#foo=bar");
+    }
+
+    @Test
+    public void findsMultipleTags() throws Exception {
+        statsD.connect();
+        statsD.send("name[foo=bar,gorch,plorp]", "value", null);
+
+        assertThat(new String(bytesCaptor.getValue()))
+                .isEqualTo("name:value|g|#foo=bar,gorch,plorp");
+    }
+
+    @Test
+    public void findsAndSantizesTags() throws Exception {
+        statsD.connect();
+        statsD.send("name[foo=bar,go rch,plorp]", "value", null);
+
+        assertThat(new String(bytesCaptor.getValue()))
+                .isEqualTo("name:value|g|#foo=bar,go-rch,plorp");
+    }
+
+    @Test
     public void address() throws IOException {
         statsD.connect();
         statsD.send("name", "value", null);
 
         assertThat(addressCaptor.getValue()).isEqualTo(address);
     }
-    
+
     @Test
     public void testTags() throws Exception {
         statsD.connect();
         statsD.send("name", "value", new String[] {"my", "tags"});
-        
+
         assertThat(new String(bytesCaptor.getValue())).isEqualTo(
                 "name:value|g|#my,tags");
     }


### PR DESCRIPTION
# What this patch does

This patch adds per-metric tags by allowing the user to embed them in to the metric's name.  For example the gauge name `thing.whatever[poop]` will be converted to `thing.whatever|g|#poop` when sent to statsd!
# Motivation

The metrics library does not have a facility for tags so we must create metric names (via their string identifier) that are unique for each set of tags. To make the tag notation clear we'll use brackets (i.e. [ ]) to clearly differentiate the tag from the metric's name.

Note: This style of tagging is used in Datadog's [recommended Java libraries](http://docs.datadoghq.com/libraries/#community-java) of [bazaarvoice/metrics-datadog](https://github.com/bazaarvoice/metrics-datadog) and [coursera/metrics-datadog](https://github.com/coursera/metrics-datadog). They unfortunately do not seem to document this behavior clearly anywhere but you can see the code [here](https://github.com/bazaarvoice/metrics-datadog/blob/master/metrics-datadog/src/main/java/com/codahale/metrics/datadog/model/DatadogSeries.java#L21).
# Testing

I've included tests for single tags, multiple tags and also tags with spaces to verify that they are sanitized.
# Thanks!

I appreciate you looking this over. Please let me know if I can do any more work to make this PR acceptable. This functionality is essential to a project I'm working on and I would love to use it as soon as I can!
